### PR TITLE
fix for Github security updates

### DIFF
--- a/background.js
+++ b/background.js
@@ -9,7 +9,7 @@ function overrideGithubCSP() {
       var isCSPHeader = /content-security-policy/i.test(details.responseHeaders[i].name);
       if (isCSPHeader) {
         var csp = details.responseHeaders[i].value;
-        csp = csp.replace('media-src', 'media-src ' + mediaHosts);
+        csp = csp.replace(/media-src.*?;/, 'media-src ' + mediaHosts + ';');
         details.responseHeaders[i].value = csp;
       }
     }

--- a/gifv.js
+++ b/gifv.js
@@ -52,14 +52,16 @@ function replaceGifvLinks(comments) {
 
       if (!anchor.href.match(gifvRegex)) {
         // not a gifv link
-        return
+        continue
       }
 
+      var httpsLink = anchor.href.replace('http://', 'https://');
+
       // Replace the anchor text with the gifv
-      var newVideo = buildGifvVideoEmbed(anchor.href);
+      var newVideo = buildGifvVideoEmbed(httpsLink);
       if (newVideo === null) {
         // failed to get a valid video
-        return
+        continue
       }
       anchor.textContent = '';
       anchor.appendChild(newVideo);


### PR DESCRIPTION
- Github is specifying a `media-src: 'none'` CSP, so we need to clobber that with the allowed media hosts using a regex
- Replace a few `returns` inside of the `for` loop with `continue` so that the script works even if the gifv isn't the first link in the comment

party on!

http://i.imgur.com/yQFnbKJ.gifv
